### PR TITLE
docs: add tables for core libraries

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,5 @@
 ## Hey there 👋
+
 ![An image of the bitcoin development kit logo](https://github.com/bitcoindevkit/.github/blob/master/profile/bdk-banner.png?raw=true)
 
 Bitcoin Development Kit (BDK) is a library that allows you to seamlessly build cross-platform Bitcoin wallets without worrying about bitcoin internals.
@@ -7,13 +8,51 @@ BDK is based on the powerful [`rust-bitcoin`](https://github.com/rust-bitcoin/ru
 
 Learn the simplest way to integrate Bitcoin wallet features into any application at [bitcoindevkit.org](https://bitcoindevkit.org/).
 
-### 🔨 Contributing to the ecosystem
-Our team maintains [bdk](https://github.com/bitcoindevkit/bdk) which is the core library, while also maintaining a number of other related open source projects like:
- - [BDK CLI](https://github.com/bitcoindevkit/bdk-cli) - A CLI wallet library and REPL tool to demo and test the BDK library
- - [BDK FFI](https://github.com/bitcoindevkit/bdk-ffi) - A foreign language bindings generator for BDK (experimental)
- - [BDK Documentation](https://bitcoindevkit.org/) - Our open source documentation
+### Our core libraries
+
+The core libraries are developed and maintained collectively by the Bitcoin Dev Kit devs. The following table outlines those libraries as well as a lead maintainer for each of them.
+
+| Library                 | Repository                                                                    | Lead Maintainer    |
+| ----------------------- | ----------------------------------------------------------------------------- | ------------------ |
+| `bdk_wallet`            | [bdk](https://github.com/bitcoindevkit/bdk)                                   | [ValuedMammal]     |
+| `bdk_chain`             | [bdk](https://github.com/bitcoindevkit/bdk)                                   | [LagginTimes]      |
+| `bdk_core`              | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |
+| `bdk_esplora`           | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |
+| `bdk_electrum`          | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |
+| `bdk_bitcoind_rpc`      | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |
+| `bdk_file_store`        | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |
+| `electrum-client`       | [rust-electrum-client](https://github.com/bitcoindevkit/rust-electrum-client) |                    |
+| `esplora-client`        | [rust-esplora-client](https://github.com/bitcoindevkit/rust-esplora-client)   |                    |
+| `bdk-kyoto`             | [bdk-kyoto](https://github.com/bitcoindevkit/bdk-kyoto)                       | [rustaceanrob]     |
+| `BitcoinDevkit` (Swift) | [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi)                           | [reez]             |
+| `bdk-android` (Kotlin)  | [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi)                           | [thunderbiscuit]   |
+| `bdk-jvm` (Kotlin)      | [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi)                           | [thunderbiscuit]   |
+| `bdkpython` (Python)    | [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi)                           | [thunderbiscuit]   |
+
+### Our documentation
+
+We maintain multiple documentation and documentation-related codebases. The following table outlines them and their official maintainer.
+
+| Project                               | Repository                  | Lead Maintainer  |
+| ------------------------------------- | --------------------------- | ---------------- |
+| [bitcoindevkit.org]                   | [bitcoindevkit.org]         |                  |
+| BdkSwiftExampleWallet                 | [BDKSwiftExampleWallet]     | [reez]           |
+| Devkit Wallet                         | [bdk-kotlin-example-wallet] | [thunderbiscuit] |
+| [Book of BDK](https://bookofbdk.com)  | [book-of-bdk]               | [thunderbiscuit] |
 
 ### 😃 Join our community
+
 Open source is fundamental to this project and we would love to connect with you.
 
 Most of our communication happens on the BDK [discord server](https://discord.gg/UbTmGbNF3M), come say hi!
+
+[ValuedMammal]: https://github.com/ValuedMammal 
+[LagginTimes]: https://github.com/LagginTimes
+[reez]: https://github.com/reez
+[thunderbiscuit]: https://github.com/thunderbiscuit
+[rustaceanrob]: https://github.com/rustaceanrob
+
+[bitcoindevkit.org]: https://bitcoindevkit.org/
+[BDKSwiftExampleWallet]: https://github.com/bitcoindevkit/BDKSwiftExampleWallet
+[bdk-kotlin-example-wallet]: https://github.com/bitcoindevkit/bdk-kotlin-example-wallet
+[book-of-bdk]: https://github.com/bitcoindevkitbook-of-bdk


### PR DESCRIPTION
This PR adds two tables that aim to make explicit the lead maintainer on each of the libraries the foundation is responsible for. It's pretty drafty right now; I figured this was a good place to discuss who is lead on each of the libraries.

I took inspiration from the [rust-bitcoin page](https://github.com/rust-bitcoin). 