### PR TITLE
Fix links in readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -37,7 +37,7 @@ We maintain multiple documentation and documentation-related codebases. The foll
 | ------------------------------------- | --------------------------- | ---------------- |
 | [bitcoindevkit.org]                   | [bitcoindevkit.org]         |                  |
 | BdkSwiftExampleWallet                 | [BDKSwiftExampleWallet]     | [reez]           |
-| Devkit Wallet                         | [bdk-kotlin-example-wallet] | [thunderbiscuit] |
+| Devkit Wallet                         | [devkit-wallet]             | [thunderbiscuit] |
 | [Book of BDK](https://bookofbdk.com)  | [book-of-bdk]               | [thunderbiscuit] |
 
 ### 😃 Join our community
@@ -54,5 +54,5 @@ Most of our communication happens on the BDK [discord server](https://discord.gg
 
 [bitcoindevkit.org]: https://bitcoindevkit.org/
 [BDKSwiftExampleWallet]: https://github.com/bitcoindevkit/BDKSwiftExampleWallet
-[bdk-kotlin-example-wallet]: https://github.com/bitcoindevkit/bdk-kotlin-example-wallet
+[devkit-wallet]: https://github.com/bitcoindevkit/devkit-wallet
 [book-of-bdk]: https://github.com/bitcoindevkitbook-of-bdk

--- a/profile/README.md
+++ b/profile/README.md
@@ -35,7 +35,7 @@ We maintain multiple documentation and documentation-related codebases. The foll
 
 | Project                               | Repository                  | Lead Maintainer  |
 | ------------------------------------- | --------------------------- | ---------------- |
-| [bitcoindevkit.org]                   | [bitcoindevkit.org]         |                  |
+| [https://bitcoindevkit.org]           | [bitcoindevkit.org]         |                  |
 | BdkSwiftExampleWallet                 | [BDKSwiftExampleWallet]     | [reez]           |
 | Devkit Wallet                         | [devkit-wallet]             | [thunderbiscuit] |
 | [Book of BDK](https://bookofbdk.com)  | [book-of-bdk]               | [thunderbiscuit] |
@@ -52,7 +52,8 @@ Most of our communication happens on the BDK [discord server](https://discord.gg
 [thunderbiscuit]: https://github.com/thunderbiscuit
 [rustaceanrob]: https://github.com/rustaceanrob
 
-[bitcoindevkit.org]: https://bitcoindevkit.org/
+[https://bitcoindevkit.org]: https://bitcoindevkit.org
+[bitcoindevkit.org]: https://github.com/bitcoindevkit/bitcoindevkit.org
 [BDKSwiftExampleWallet]: https://github.com/bitcoindevkit/BDKSwiftExampleWallet
 [devkit-wallet]: https://github.com/bitcoindevkit/devkit-wallet
 [book-of-bdk]: https://github.com/bitcoindevkitbook-of-bdk


### PR DESCRIPTION
This PR addresses 2 things:

1. The repo link in the readme table was linking to the website instead of the repo.
2. I changed the Devkit Wallet repo back to its original name, `devkit-wallet`. I was never fond of the new repo name (`bdk-kotlin-example-wallet`... we don't even maintain a library called bdk-kotlin???). It's always been called the Devkit Wallet since the very first commit. I think now with this awesome table our sample apps and documentation are easier to find than ever, so I brought back the old tried and true name of the app.