### PR TITLE
Add links for new bdk-jvm and bdkpython repositories

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -12,23 +12,23 @@ Learn the simplest way to integrate Bitcoin wallet features into any application
 
 The core libraries are developed and maintained collectively by the Bitcoin Dev Kit devs. The following table outlines those libraries as well as a lead maintainer for each of them.
 
-| Library                 | Repository                                                                    | Lead Maintainer    |
-| ----------------------- | ----------------------------------------------------------------------------- | ------------------ |
-| `bdk_wallet`            | [bdk_wallet](https://github.com/bitcoindevkit/bdk_wallet)                     | [ValuedMammal]     |
-| `bdk_chain`             | [bdk](https://github.com/bitcoindevkit/bdk)                                   | [evanlinjin]       |
-| `bdk_core`              | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |
-| `bdk_tx`                | [bdk-tx](https://github.com/bitcoindevkit/bdk-tx)                             |                    |
-| `bdk_esplora`           | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |
-| `bdk_electrum`          | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |
-| `bdk_bitcoind_rpc`      | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |
-| `bdk_file_store`        | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |
-| `electrum-client`       | [rust-electrum-client](https://github.com/bitcoindevkit/rust-electrum-client) |                    |
-| `esplora-client`        | [rust-esplora-client](https://github.com/bitcoindevkit/rust-esplora-client)   |                    |
-| `bdk-kyoto`             | [bdk-kyoto](https://github.com/bitcoindevkit/bdk-kyoto)                       | [rustaceanrob]     |
-| `BitcoinDevKit` (Swift) | [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi)                           | [reez]             |
-| `bdk-android` (Kotlin)  | [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi)                           | [thunderbiscuit]   |
-| `bdk-jvm` (Kotlin)      | [bdk-jvm](https://github.com/bitcoindevkit/bdk-jvm)                           | [thunderbiscuit]   |
-| `bdkpython` (Python)    | [bdkpython](https://github.com/bitcoindevkit/bdkpython)                       |                    |
+| Library                 | Repository                                                                    | Lead Maintainer    | Secondary Maintainer |
+| ----------------------- | ----------------------------------------------------------------------------- | ------------------ | -------------------- |
+| `bdk_wallet`            | [bdk_wallet](https://github.com/bitcoindevkit/bdk_wallet)                     | [ValuedMammal]     |                      |
+| `bdk_chain`             | [bdk](https://github.com/bitcoindevkit/bdk)                                   | [evanlinjin]       |                      |
+| `bdk_core`              | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |                      |
+| `bdk_tx`                | [bdk-tx](https://github.com/bitcoindevkit/bdk-tx)                             |                    |                      |
+| `bdk_esplora`           | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |                      |
+| `bdk_electrum`          | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |                      |
+| `bdk_bitcoind_rpc`      | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |                      |
+| `bdk_file_store`        | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |                      |
+| `electrum-client`       | [rust-electrum-client](https://github.com/bitcoindevkit/rust-electrum-client) |                    |                      |
+| `esplora-client`        | [rust-esplora-client](https://github.com/bitcoindevkit/rust-esplora-client)   |                    |                      |
+| `bdk-kyoto`             | [bdk-kyoto](https://github.com/bitcoindevkit/bdk-kyoto)                       | [rustaceanrob]     |                      |
+| `bdk-swift` (Swift)     | [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi)                           | [reez]             |                      |
+| `bdk-android` (Kotlin)  | [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi)                           | [thunderbiscuit]   |                      |
+| `bdk-jvm` (Kotlin)      | [bdk-jvm](https://github.com/bitcoindevkit/bdk-jvm)                           | [thunderbiscuit]   |                      |
+| `bdk-python` (Python)   | [bdk-python](https://github.com/bitcoindevkit/bdk-python)                     |                    |                      |
 
 ### Our documentation
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -30,16 +30,17 @@ The core libraries are developed and maintained collectively by the Bitcoin Dev 
 | `bdk-jvm` (Kotlin)      | [bdk-jvm](https://github.com/bitcoindevkit/bdk-jvm)                           | [thunderbiscuit]   |                      |
 | `bdk-python` (Python)   | [bdk-python](https://github.com/bitcoindevkit/bdk-python)                     |                    |                      |
 
-### Our documentation
+### Documentation and Tools
 
 We maintain multiple documentation and documentation-related codebases. The following table outlines them and their official maintainer.
 
 | Project                               | Repository                  | Lead Maintainer  |
 | ------------------------------------- | --------------------------- | ---------------- |
-| [https://bitcoindevkit.org]           | [bitcoindevkit.org]         |                  |
+| [https://bitcoindevkit.org]           | [bitcoindevkit.org]         | [reez]           |
 | BdkSwiftExampleWallet                 | [BDKSwiftExampleWallet]     | [reez]           |
 | Devkit Wallet                         | [devkit-wallet]             | [thunderbiscuit] |
 | [Book of BDK](https://bookofbdk.com)  | [book-of-bdk]               | [thunderbiscuit] |
+| [bdk-cli]                             | [bdk-cli]                   | [tvpeter]        |
 
 ### 😃 Join our community
 
@@ -53,9 +54,11 @@ Most of our communication happens on the BDK [discord server](https://discord.gg
 [reez]: https://github.com/reez
 [thunderbiscuit]: https://github.com/thunderbiscuit
 [rustaceanrob]: https://github.com/rustaceanrob
+[tvpeter]: https://github.com/tvpeter
 
 [https://bitcoindevkit.org]: https://bitcoindevkit.org
 [bitcoindevkit.org]: https://github.com/bitcoindevkit/bitcoindevkit.org
 [BDKSwiftExampleWallet]: https://github.com/bitcoindevkit/BDKSwiftExampleWallet
 [devkit-wallet]: https://github.com/bitcoindevkit/devkit-wallet
 [book-of-bdk]: https://github.com/bitcoindevkit/book-of-bdk
+[bdk-cli]: https://github.com/bitcoindevkit/bdk-cli

--- a/profile/README.md
+++ b/profile/README.md
@@ -27,8 +27,8 @@ The core libraries are developed and maintained collectively by the Bitcoin Dev 
 | `bdk-kyoto`             | [bdk-kyoto](https://github.com/bitcoindevkit/bdk-kyoto)                       | [rustaceanrob]     |
 | `BitcoinDevKit` (Swift) | [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi)                           | [reez]             |
 | `bdk-android` (Kotlin)  | [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi)                           | [thunderbiscuit]   |
-| `bdk-jvm` (Kotlin)      | [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi)                           | [thunderbiscuit]   |
-| `bdkpython` (Python)    | [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi)                           | [thunderbiscuit]   |
+| `bdk-jvm` (Kotlin)      | [bdk-jvm](https://github.com/bitcoindevkit/bdk-jvm)                           | [thunderbiscuit]   |
+| `bdkpython` (Python)    | [bdkpython](https://github.com/bitcoindevkit/bdkpython)                       |                    |
 
 ### Our documentation
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -14,20 +14,20 @@ The core libraries are developed and maintained collectively by the Bitcoin Dev 
 
 | Library                 | Repository                                                                    | Lead Maintainer    | Secondary Maintainer |
 | ----------------------- | ----------------------------------------------------------------------------- | ------------------ | -------------------- |
-| `bdk_wallet`            | [bdk_wallet](https://github.com/bitcoindevkit/bdk_wallet)                     | [ValuedMammal]     |                      |
-| `bdk_chain`             | [bdk](https://github.com/bitcoindevkit/bdk)                                   | [evanlinjin]       |                      |
-| `bdk_core`              | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |                      |
+| `bdk_wallet`            | [bdk_wallet](https://github.com/bitcoindevkit/bdk_wallet)                     | [ValuedMammal]     | [oleonardolima]      |
+| `bdk_chain`             | [bdk](https://github.com/bitcoindevkit/bdk)                                   | [evanlinjin]       | [LagginTimes]        |
+| `bdk_core`              | [bdk](https://github.com/bitcoindevkit/bdk)                                   | [evanlinjin]       |                      |
 | `bdk_tx`                | [bdk-tx](https://github.com/bitcoindevkit/bdk-tx)                             |                    |                      |
-| `bdk_esplora`           | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |                      |
-| `bdk_electrum`          | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |                      |
+| `bdk_esplora`           | [bdk](https://github.com/bitcoindevkit/bdk)                                   | [oleonardolima]    |                      |
+| `bdk_electrum`          | [bdk](https://github.com/bitcoindevkit/bdk)                                   | [LagginTimes]      |                      |
 | `bdk_bitcoind_rpc`      | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |                      |
 | `bdk_file_store`        | [bdk](https://github.com/bitcoindevkit/bdk)                                   |                    |                      |
-| `electrum-client`       | [rust-electrum-client](https://github.com/bitcoindevkit/rust-electrum-client) |                    |                      |
-| `esplora-client`        | [rust-esplora-client](https://github.com/bitcoindevkit/rust-esplora-client)   |                    |                      |
+| `electrum-client`       | [rust-electrum-client](https://github.com/bitcoindevkit/rust-electrum-client) | [LagginTimes]      |                      |
+| `esplora-client`        | [rust-esplora-client](https://github.com/bitcoindevkit/rust-esplora-client)   | [oleonardolima]    |                      |
 | `bdk-kyoto`             | [bdk-kyoto](https://github.com/bitcoindevkit/bdk-kyoto)                       | [rustaceanrob]     |                      |
 | `bdk-swift` (Swift)     | [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi)                           | [reez]             |                      |
 | `bdk-android` (Kotlin)  | [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi)                           | [thunderbiscuit]   |                      |
-| `bdk-jvm` (Kotlin)      | [bdk-jvm](https://github.com/bitcoindevkit/bdk-jvm)                           | [thunderbiscuit]   |                      |
+| `bdk-jvm` (Kotlin)      | [bdk-jvm](https://github.com/bitcoindevkit/bdk-jvm)                           | [thunderbiscuit]   | [ItoroD]             |
 | `bdk-python` (Python)   | [bdk-python](https://github.com/bitcoindevkit/bdk-python)                     |                    |                      |
 
 ### Documentation and Tools
@@ -54,7 +54,10 @@ Most of our communication happens on the BDK [discord server](https://discord.gg
 [reez]: https://github.com/reez
 [thunderbiscuit]: https://github.com/thunderbiscuit
 [rustaceanrob]: https://github.com/rustaceanrob
+[oleonardolima]: https://github.com/oleonardolima
 [tvpeter]: https://github.com/tvpeter
+[LagginTimes]: https://github.com/LagginTimes
+[ItoroD]: https://github.com/ItoroD
 
 [https://bitcoindevkit.org]: https://bitcoindevkit.org
 [bitcoindevkit.org]: https://github.com/bitcoindevkit/bitcoindevkit.org


### PR DESCRIPTION
The Python and JVM libraries have been broken into their own repositories. This reflects that.