### PR TITLE
readme: add bdk-bip322 to experimental section

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -115,9 +115,11 @@ The lead and secondary maintainers for each project are responsible for:
 | --------------------------- | ---------------------- | ---------------------- |
 | [bdk_sqlx]                  | [matthiasdebernardini] |                        |
 | [bitcoin-ffi]               |                        |                        |
+| [bdk-bip322]                | [aagbotemi]            |                        |
 
 [bdk_sqlx]: https://github.com/bitcoindevkit/bdk-sqlx
 [bitcoin-ffi]: https://github.com/bitcoindevkit/bitcoin-ffi
+[bdk-bip322]: https://github.com/bitcoindevkit/bdk-bip322
 
 ### 😃 Join our community
 


### PR DESCRIPTION
Added [bdk-bip322](https://github.com/bitcoindevkit/bdk-bip322) to the experimental section with @aagbotemi as the maintainer.